### PR TITLE
Add roothide support for RemoteCompanion build

### DIFF
--- a/Tweak/Makefile
+++ b/Tweak/Makefile
@@ -5,11 +5,16 @@ THEOS_DEVICE_IP = iphone.local
 INSTALL_TARGET_USER = mobile
 TARGET := iphone:clang:latest:14.0
 INSTALL_TARGET_PROCESSES = SpringBoard
-ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
+
+# Support for both rootless and roothide
+ifeq ($(THEOS_PACKAGE_SCHEME),roothide)
+ARCHS = arm64 arm64e
+else ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
 ARCHS = arm64 arm64e
 else
 ARCHS = arm64 arm64e
 endif
+
 THEOS_PACKAGE_SCHEME ?= rootless
 
 include $(THEOS)/makefiles/common.mk
@@ -29,5 +34,4 @@ include $(THEOS_MAKE_PATH)/tweak.mk
 
 SUBPROJECTS += rc-root
 SUBPROJECTS += rc-client
-# SUBPROJECTS += ../RemoteCompanion
 include $(THEOS_MAKE_PATH)/aggregate.mk

--- a/Tweak/entitlements.plist
+++ b/Tweak/entitlements.plist
@@ -4,7 +4,11 @@
 <dict>
 	<key>platform-application</key>
 	<true/>
-	<key>com.apple.private.security.no-container</key>
+	<key>com.apple.private.security.no-sandbox</key>
+	<true/>
+	<key>com.apple.private.security.storage.AppBundles</key>
+	<true/>
+	<key>com.apple.private.security.storage.AppDataContainers</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
- Update Makefile to support THEOS_PACKAGE_SCHEME=roothide
- Update entitlements.plist with roothide-required entitlements
- Add support for both rootless and roothide jailbreak environments